### PR TITLE
Allow for use with Windows Server 2016.

### DIFF
--- a/Add-Store.cmd
+++ b/Add-Store.cmd
@@ -1,5 +1,4 @@
 @echo off
-for /f "tokens=6 delims=[]. " %%G in ('ver') do if %%G lss 14393 goto :version
 %windir%\system32\reg.exe query "HKU\S-1-5-19" 1>nul 2>nul || goto :uac
 setlocal enableextensions
 if /i "%PROCESSOR_ARCHITECTURE%" equ "AMD64" (set "arch=x64") else (set "arch=x86")

--- a/Add-Store.cmd
+++ b/Add-Store.cmd
@@ -106,17 +106,6 @@ echo Press any key to Exit
 pause >nul
 exit
 
-:version
-echo.
-echo ============================================================
-echo Error: This pack is for Windows 10 version 1607 and later
-echo ============================================================
-echo.
-echo.
-echo Press any key to Exit
-pause >nul
-exit
-
 :nofiles
 echo.
 echo ============================================================

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-I want to make absolutely clear that this project was created by kkkgo.  I have simply made some very minor changes for compatability with the Windows Server 2016 used by Paperspace's Core machines
+I want to make absolutely clear that this project was created by kkkgo.  I have simply made some very minor changes for compatability with the version of Windows Server 2016 used by Paperspace's Core machines
 
 # Add Store to Windows 10 Enterprise LTSB  
 For Windows 10 Enterprise 2015 / 2016 LTSB or Windows Enterprise 2015 / 2016 LTSB N  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-I want to make absolutely clear that this project was created by kkkgo.  I have simple made some very minor changes for compatability with Windows Server 2016.
+I want to make absolutely clear that this project was created by kkkgo.  I have simply made some very minor changes for compatability with Windows Server 2016.
 
 # Add Store to Windows 10 Enterprise LTSB  
 For Windows 10 Enterprise 2015 / 2016 LTSB or Windows Enterprise 2015 / 2016 LTSB N  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-I want to make absolutely clear that this project was created by kkkgo.  I have simply made some very minor changes for compatability with Windows Server 2016.
+I want to make absolutely clear that this project was created by kkkgo.  I have simply made some very minor changes for compatability with the Windows Server 2016 used by Paperspace's Core machines
 
 # Add Store to Windows 10 Enterprise LTSB  
 For Windows 10 Enterprise 2015 / 2016 LTSB or Windows Enterprise 2015 / 2016 LTSB N  

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+I want to make absolutely clear that this project was created by kkkgo.  I have simple made some very minor changes for compatability with Windows Server 2016.
+
 # Add Store to Windows 10 Enterprise LTSB  
 For Windows 10 Enterprise 2015 / 2016 LTSB or Windows Enterprise 2015 / 2016 LTSB N  
 [Download](https://github.com/lixuy/LTSB-Add-MicrosoftStore/archive/2016.zip)  


### PR DESCRIPTION
Remove version check to allow for use with Windows Server 2016.  The check probably isn't necessary.  Confirmed working.